### PR TITLE
Fix logging of invalid records on bad data.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
         environment:
           SCHEMA_REGISTRY_HOST_NAME: localhost
           SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'localhost:2181'
+      - image: redis:2.8
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
         environment:
           SCHEMA_REGISTRY_HOST_NAME: localhost
           SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'localhost:2181'
-      - image: redis:2.8
 
     steps:
       - checkout

--- a/Tests/Utils/Fakes/FakeFactory.php
+++ b/Tests/Utils/Fakes/FakeFactory.php
@@ -14,4 +14,12 @@ class FakeFactory
         $fake->setId($id);
         return $fake;
     }
+
+    public static function invalidRecord(): FakeRecord
+    {
+        $fake = new FakeRecord();
+        $fake->setId(Factory::create()->word);
+        return $fake;
+    }
+
 }


### PR DESCRIPTION
We were not logging invalid events to "invalid-" from our PHP producer, since it was just throwing "SchemaRegistryException". This distinguishes between exceptions.